### PR TITLE
Fix encoding

### DIFF
--- a/run.py
+++ b/run.py
@@ -22,7 +22,7 @@ def retry_event():
             'Cache-Control': 'no-cache',
             'User-Agent': 'Stripe/1.0 (+https://stripe.com/docs/webhooks)',
         },
-        data=event_data
+        data=event_data.encode('utf-8')
     )
     return (
         json.dumps({'success': bool(r.status_code == 200)}),


### PR DESCRIPTION
Fix encoding in `UTF-8` when event payload contains chars that are not supported by `latin-1`